### PR TITLE
bump: v1.0.0-rc95

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN set -x \
 # setup the build
 ARG PKG="github.com/opencontainers/runc"
 ARG SRC="github.com/opencontainers/runc"
-ARG TAG="v1.0.0-rc94"
+ARG TAG="v1.0.0-rc95"
 RUN git clone --depth=1 https://${SRC}.git $GOPATH/src/${PKG}
 WORKDIR $GOPATH/src/${PKG}
 RUN git fetch --all --tags --prune

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ BUILD_META=-build$(shell date +%Y%m%d)
 ORG ?= rancher
 PKG ?= github.com/opencontainers/runc
 SRC ?= github.com/opencontainers/runc
-TAG ?= v1.0.0-rc94$(BUILD_META)
+TAG ?= v1.0.0-rc95$(BUILD_META)
 
 ifneq ($(DRONE_TAG),)
 TAG := $(DRONE_TAG)


### PR DESCRIPTION
Address [CVE-2021-30465](https://github.com/opencontainers/runc/security/advisories/GHSA-c3xm-pvg7-gh7r)