### PR TITLE
bump runc tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN set -x && \
 # setup the build
 ARG PKG="github.com/opencontainers/runc"
 ARG SRC="github.com/opencontainers/runc"
-ARG TAG="v1.2.6"
+ARG TAG="v1.2.7"
 ARG TARGETARCH="amd64"
 RUN git clone --depth=1 https://${SRC}.git $GOPATH/src/${PKG}
 WORKDIR $GOPATH/src/${PKG}

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ SRC ?= github.com/opencontainers/runc
 TAG ?= ${GITHUB_ACTION_TAG}
 
 ifeq ($(TAG),)
-TAG := v1.1.12$(BUILD_META)
+TAG := v1.2.7$(BUILD_META)
 endif
 
 ifeq (,$(filter %$(BUILD_META),$(TAG)))


### PR DESCRIPTION
I know we don't /actually/ need this PR as the tag is set at buildtime, but good to have it up to date regardless