### PR TITLE
Bump hardened-build-base to v1.25.12b1 and override golang.org/x/net for CVE fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_IMAGE=rancher/hardened-build-base:v1.25.10b1
+ARG GO_IMAGE=rancher/hardened-build-base:v1.25.12b1
 FROM ${GO_IMAGE} as builder
 # setup required packages
 RUN set -x && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,8 @@ RUN git clone --depth=1 https://${SRC}.git $GOPATH/src/${PKG}
 WORKDIR $GOPATH/src/${PKG}
 RUN git fetch --all --tags --prune
 RUN git checkout tags/${TAG} -b ${TAG}
+COPY go-mod-overrides ./go-mod-overrides
+RUN go-mod-overrides.sh ./go-mod-overrides
 RUN BUILDTAGS='seccomp selinux apparmor' GOEXPERIMENT='boringcrypto' make static
 RUN go-assert-static.sh runc
 RUN if [ "${TARGETARCH}" = "amd64" ]; then \

--- a/go-mod-overrides
+++ b/go-mod-overrides
@@ -1,0 +1,3 @@
+# golang.org/x/net: CVE-2026-33814 (net/http2 DoS), CVE-2026-39821 (x/net/idna punycode).
+# Drop once upstream runc requires golang.org/x/net >= v0.55.0.
+-replace golang.org/x/net=golang.org/x/net@v0.55.0


### PR DESCRIPTION
## Summary

Two changes to fix Go CVEs in the `hardened-runc` image:

1. **Bump `hardened-build-base` to `v1.25.12b1`** — picks up the latest Go CVE fix (patch bump, stays on the 1.25 line).
2. **Override `golang.org/x/net` to `v0.55.0`** via the shared, declarative go.mod override mechanism (mirrors rancher/image-build-dns-nodecache#177):
   - **CVE-2026-33814** — `net/http2` DoS via a malformed `SETTINGS_MAX_FRAME_SIZE` frame (fixed in `golang.org/x/net` v0.53.0)
   - **CVE-2026-39821** — `x/net/idna` privilege escalation via incorrect Punycode label processing (fixed in `golang.org/x/net` v0.55.0)

   runc `v1.4.1` pins `golang.org/x/net v0.43.0`, which is still vulnerable. A repo-root `go-mod-overrides` file pins it to `v0.55.0` (covers both CVEs), and the Dockerfile builder runs the shared `go-mod-overrides.sh` (ships in `hardened-build-base`) before `make static` so the pin is applied and re-vendored.

## Note

The shared `go-mod-overrides.sh` was only just merged into `rancher/image-build-base` (#105) and is **not yet present in a released `hardened-build-base` tag**. This PR is intentionally opened ahead of that: it will build green once a new `hardened-build-base` tag is cut with the script and the `GO_IMAGE` here is bumped to it.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>