### PR TITLE
Use native arm runners for PR build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
         trivyignores: '.trivyignore'
 
   build-arm64:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
     - name: Check out code
       uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4


### PR DESCRIPTION
Goes from ~7min of build to ~1min of build.

Signed-off-by: Derek Nola <derek.nola@suse.com>